### PR TITLE
Fix baseURL from relative path to absolute path

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseURL: /
+baseURL: https://tech.cloudmt.co.kr
 title: 클라우드메이트 기술 블로그🦒
 theme:
   - github.com/jonathanjanssens/hugo-casper3


### PR DESCRIPTION
Currently, `baseURL` is set as a relative path, so link of RSS is provided as a relative path.